### PR TITLE
feat: add entrypoint script for automatic database migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,14 @@ COPY pyproject.toml uv.lock /mlflow/
 RUN uv sync --frozen --no-install-project --no-cache
 
 FROM base AS final
+USER root
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 USER python
 WORKDIR /mlflow
 COPY --from=builder --chown=python:python /mlflow /mlflow
 ENV PATH=/mlflow/.venv/bin:$PATH
 ENV OAUTHLIB_INSECURE_TRANSPORT=1
 EXPOSE 5000
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["mlflow", "server", "--host", "0.0.0.0", "--port", "5000", "--app-name", "oidc-auth", "--backend-store-uri", "sqlite:///mlflow.db", "--default-artifact-root", "/mlflow/artifacts"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+echo "Running database migrations..."
+# Find the mlflow_oidc_auth package location and run alembic from its migrations directory
+MIGRATIONS_DIR=$(python -c "import mlflow_oidc_auth; import os; print(os.path.join(os.path.dirname(mlflow_oidc_auth.__file__), 'db', 'migrations'))")
+cd "$MIGRATIONS_DIR"
+alembic upgrade head
+
+echo "Starting MLflow server..."
+exec "$@"

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,22 @@ The image is rebuilt automatically on a daily basis if a new version of the MLfl
 
 The Docker image tags follow this pattern: **MLflow version - OIDC Auth plugin version - Image Build Date**.
 
+# Database Migrations
+
+The container automatically runs database migrations on startup using Alembic. This ensures your database schema is always up-to-date when upgrading to a new version.
+
+If you need to run migrations manually (e.g., for troubleshooting), you can execute:
+
+```bash
+docker exec <container> sh -c 'cd $(python -c "import mlflow_oidc_auth, os; print(os.path.join(os.path.dirname(mlflow_oidc_auth.__file__), \"db\", \"migrations\"))") && alembic upgrade head'
+```
+
+To check the current migration status:
+
+```bash
+docker exec <container> sh -c 'cd $(python -c "import mlflow_oidc_auth, os; print(os.path.join(os.path.dirname(mlflow_oidc_auth.__file__), \"db\", \"migrations\"))") && alembic current'
+```
+
 # Kubernetes Deployment
 
 A Helm chart for deploying this image to Kubernetes can be found [here](https://github.com/mlflow-oidc/helm).


### PR DESCRIPTION
Add entrypoint.sh that runs alembic migrations before starting the MLflow server. This ensures database schema is always up-to-date when the container starts.